### PR TITLE
feat(llm): support custom Anthropic base URL and auth token

### DIFF
--- a/kernel-evolve/README.md
+++ b/kernel-evolve/README.md
@@ -92,7 +92,7 @@ evolution:
 
 llm:
   provider: "anthropic"               # anthropic | google | openai
-  model: "claude-sonnet-4-6"
+  model: "claude-opus-4-6"
   temperature: 0.7
 ```
 
@@ -157,4 +157,4 @@ pip install -e ".[google]"      # Gemini
 pip install -e ".[openai]"      # Codex / GPT
 ```
 
-Set the corresponding API key environment variable (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, or `OPENAI_API_KEY`).
+Set the corresponding API key environment variable (`ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, or `OPENAI_API_KEY`). Optionally set `ANTHROPIC_BASE_URL` to use a custom API endpoint.

--- a/kernel-evolve/examples/matmul.yaml
+++ b/kernel-evolve/examples/matmul.yaml
@@ -24,7 +24,7 @@ evolution:
 
 llm:
   provider: "anthropic"
-  model: "claude-sonnet-4-6"
+  model: "claude-opus-4-6"
   temperature: 0.7
 
 tpu:

--- a/kernel-evolve/src/kernel_evolve/llm/anthropic_provider.py
+++ b/kernel-evolve/src/kernel_evolve/llm/anthropic_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 
 from kernel_evolve.llm.base import LLMProvider, MutationRequest, MutationResponse
@@ -32,10 +33,12 @@ Output format:
 
 
 class AnthropicProvider(LLMProvider):
-  def __init__(self, model: str = "claude-sonnet-4-6", temperature: float = 0.7):
+  def __init__(self, model: str = "claude-opus-4-6", temperature: float = 0.7):
     self._model = model
     self._temperature = temperature
-    self._client = AsyncAnthropic()
+    api_key = os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    self._client = AsyncAnthropic(api_key=api_key, base_url=base_url)
 
   async def mutate(self, request: MutationRequest) -> MutationResponse:
     user_prompt = self._build_prompt(request)

--- a/kernel-evolve/tests/test_cli.py
+++ b/kernel-evolve/tests/test_cli.py
@@ -24,7 +24,7 @@ shapes:
   - {{ M: 64 }}
 llm:
   provider: "anthropic"
-  model: "claude-sonnet-4-6"
+  model: "claude-opus-4-6"
 tpu:
   cluster: "c"
   zone: "z"

--- a/kernel-evolve/tests/test_config.py
+++ b/kernel-evolve/tests/test_config.py
@@ -31,7 +31,7 @@ def test_config_defaults():
   cfg = EvolveConfig(
     kernel={"name": "test", "template": "k.py", "reference": "r.py"},
     shapes=[{"M": 64, "N": 64, "K": 64}],
-    llm={"provider": "anthropic", "model": "claude-sonnet-4-6"},
+    llm={"provider": "anthropic", "model": "claude-opus-4-6"},
     tpu={"cluster": "c", "zone": "z", "tpu_type": "v4-8", "image": "img"},
   )
   assert cfg.evolution.population_size == 25

--- a/kernel-evolve/tests/test_engine.py
+++ b/kernel-evolve/tests/test_engine.py
@@ -16,7 +16,7 @@ def minimal_config():
     kernel={"name": "test", "template": "k.py", "reference": "r.py"},
     shapes=[{"M": 64, "N": 64, "K": 64}],
     evolution={"population_size": 4, "num_islands": 1, "max_generations": 3, "stagnation_limit": 2},
-    llm={"provider": "anthropic", "model": "claude-sonnet-4-6"},
+    llm={"provider": "anthropic", "model": "claude-opus-4-6"},
     tpu={"cluster": "c", "zone": "z", "tpu_type": "v4-8", "image": "img"},
     logging={"output_dir": "/tmp/test_run"},
   )

--- a/kernel-evolve/tests/test_llm.py
+++ b/kernel-evolve/tests/test_llm.py
@@ -51,7 +51,7 @@ async def test_anthropic_provider_mutate():
   mock_client.messages.create = AsyncMock(return_value=mock_message)
 
   with patch("kernel_evolve.llm.anthropic_provider.AsyncAnthropic", return_value=mock_client):
-    provider = AnthropicProvider(model="claude-sonnet-4-6", temperature=0.7)
+    provider = AnthropicProvider(model="claude-opus-4-6", temperature=0.7)
     req = MutationRequest(parent_code="def kernel(): pass", fitness=1.0, generation=1)
     resp = await provider.mutate(req)
     assert "optimized" in resp.mutated_code


### PR DESCRIPTION
## Summary
- Update `AnthropicProvider` to support `ANTHROPIC_AUTH_TOKEN` env var (with `ANTHROPIC_API_KEY` fallback) and `ANTHROPIC_BASE_URL` for custom API endpoints
- Change default model from `claude-sonnet-4-6` to `claude-opus-4-6` across provider, config example, tests, and documentation
- Update README to document new env vars

## Test plan
- [x] All 41 existing tests pass
- [ ] Verify `ANTHROPIC_AUTH_TOKEN` is picked up by `AnthropicProvider` when set
- [ ] Verify `ANTHROPIC_BASE_URL` routes requests to custom endpoint
- [ ] Verify fallback to `ANTHROPIC_API_KEY` when `ANTHROPIC_AUTH_TOKEN` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)