### PR TITLE
fix(pallas-evolve): enable local plugin for worktree sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "plugins": [
     { "type": "local", "path": "./kernel-evolve/plugins/pallas-evolve" }
-  ]
+  ],
+  "enabledPlugins": {
+    "pallas-evolve": true
+  }
 }


### PR DESCRIPTION
## Summary
- Add `enabledPlugins` entry for `pallas-evolve` in `.claude/settings.json` so the local plugin loads correctly in git worktree sessions

## Test plan
- [ ] Start a new Claude Code session in a worktree and verify `pallas-evolve:start`, `pallas-evolve:analyze`, `pallas-evolve:reflect`, `pallas-evolve:submit` appear in available skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)