### PR TITLE
docs(pallas-evolve): add context management notes to skills

### DIFF
--- a/kernel-evolve/plugins/pallas-evolve/skills/analyze/SKILL.md
+++ b/kernel-evolve/plugins/pallas-evolve/skills/analyze/SKILL.md
@@ -487,3 +487,14 @@ When generating suggestions for each variant, use these categories based on the 
 - Compare the current kernel with the lineage's previous best
 - Identify what changed and why it was slower
 - Suggest reverting the specific change that caused regression
+
+### Step 9: Context note
+
+All analysis outputs have been persisted to disk:
+- `iteration_{N}/batch_analysis.md` — full comparative analysis
+- `iteration_{N}/selection.md` — top-K selection rationale
+- `lineages.json` — updated lineage state
+
+**Do NOT compact here** — this skill is typically invoked within the `pallas-evolve:start` loop, which manages compaction at Phase 5 after all phases complete. Compacting mid-loop would lose orchestration context needed by subsequent phases (reflect, continue).
+
+If invoked **standalone** (outside the start loop), invoke `/compact` after this skill completes.

--- a/kernel-evolve/plugins/pallas-evolve/skills/init-kernel/SKILL.md
+++ b/kernel-evolve/plugins/pallas-evolve/skills/init-kernel/SKILL.md
@@ -539,6 +539,18 @@ If shapes could not be extracted from upstream tests, use AskUserQuestion to ask
   ```
 - Warn the user that they may need to create the custom job template (reference `.github/ci/kernel-eval-gmm-job.yaml` for the pattern).
 
+## Step 7.5 — Compact context
+
+All source files have been generated and the upstream code has been consolidated. The following files are on disk:
+- `kernel-evolve/examples/kernels/${KERNEL_NAME}_ref.py` — self-contained reference
+- `kernel-evolve/examples/kernels/${KERNEL_NAME}.py` — template with EVOLVE-BLOCK
+- `kernel-evolve/examples/${KERNEL_NAME}.yaml` — YAML config
+- `kernel-evolve/upstream/${KERNEL_NAME}/` — unmodified upstream source
+- `kernel-evolve/tests/test_${KERNEL_NAME}.py` — pytest convention tests
+- `kernel-evolve/tests/standalone_${KERNEL_NAME}_test.py` — TPU integration test
+
+Invoke `/compact` to compress conversation context before proceeding to validation. The upstream source code read during Steps 2–3 and the intermediate analysis are no longer needed in context — validation steps (8–9) will read generated files from disk.
+
 ## Step 8 — Validate generated config
 
 Validate the generated YAML config against the Pydantic schema:

--- a/kernel-evolve/plugins/pallas-evolve/skills/profile-brief/SKILL.md
+++ b/kernel-evolve/plugins/pallas-evolve/skills/profile-brief/SKILL.md
@@ -195,3 +195,11 @@ These signals are available in `eval_result.json` under `metadata.profile`:
 - `hbm_capacity_utilization_pct`: Peak HBM memory usage as % of 192 GB capacity. High values mean large buffer allocations — check for redundant intermediates.
 
 **When analyzing iteration results, check all signals — not just speedup and compute_ratio. VLIW bundle count and MXU dual_ratio are leading indicators of kernel quality.**
+
+### Step 9: Context note
+
+The profile brief has been written to `{ARTIFACTS_DIR}/profile_brief.md`. All extracted insights from the raw LLO/HLO/trace files are now captured in the brief.
+
+**Do NOT compact here** — this skill is typically invoked within the `pallas-evolve:start` loop (Phase 0), and the caller needs the profile brief content for Phase 1 (THINK). The start loop manages compaction at Phase 5.
+
+If invoked **standalone** (outside the start loop), invoke `/compact` after this skill completes — the raw IR contents (which can be thousands of lines) are no longer needed in context.

--- a/kernel-evolve/plugins/pallas-evolve/skills/reflect/SKILL.md
+++ b/kernel-evolve/plugins/pallas-evolve/skills/reflect/SKILL.md
@@ -115,3 +115,13 @@ If AGENT.md was modified, create a single commit for all changes from this round
 git add AGENT.md
 git commit -m "docs(agent): record learnings from {kernel_name} round {N}"
 ```
+
+### Step 6: Context note
+
+All learnings have been persisted:
+- `AGENT.md` — updated failure patterns and successful optimizations (committed)
+- GitHub Issue #{issue_number} — round summary comment posted
+
+**Do NOT compact here** — this skill is typically invoked within the `pallas-evolve:start` loop (Phase 4), and the subsequent Phase 5 (COMPACT) handles context compression with proper state verification. Compacting mid-loop would lose orchestration context.
+
+If invoked **standalone** (outside the start loop), invoke `/compact` after this skill completes.

--- a/kernel-evolve/plugins/pallas-evolve/skills/submit/SKILL.md
+++ b/kernel-evolve/plugins/pallas-evolve/skills/submit/SKILL.md
@@ -268,3 +268,11 @@ kubectl delete configmap ${JOB_NAME}-payload --ignore-not-found
 - If a variant has no matching `EVAL_RESULT:` in the logs: save a synthetic COMPILE_ERROR for that variant
 - Partial results are acceptable — some variants may succeed while others fail
 - Always run cleanup step (Step 9) regardless of outcome
+
+### Step 10: Context note
+
+All evaluation results have been distributed to per-variant `eval_result.json` files, artifacts downloaded, and K8s resources cleaned up.
+
+**Do NOT compact here** — this skill is typically invoked within the `pallas-evolve:start` loop (Phase 2), and the subsequent Phase 3 (ANALYZE) needs orchestration context (iteration number, run directory) to locate results. The start loop manages compaction at Phase 5.
+
+If invoked **standalone** (outside the start loop), invoke `/compact` after this skill completes — the K8s Job logs, base64 payload, and polling output are no longer needed in context.


### PR DESCRIPTION
## Summary

- Add context notes to 4 loop-internal sub-skills (analyze, submit, reflect, profile-brief) warning against mid-loop `/compact` — compacting here would lose orchestration context (iteration number, run directory, config) needed by subsequent phases in the `start` loop
- Add proactive `/compact` step to `init-kernel` (Step 7.5) after all files are generated — this skill runs standalone so compaction is safe and frees upstream source code from context before validation
- Loop-internal skills note that standalone invocations should compact after completion

## Test plan

- [ ] Verify `pallas-evolve:start` loop still works correctly (sub-skills don't compact mid-loop)
- [ ] Verify `pallas-evolve:init-kernel` compacts after Step 7 when run standalone
- [ ] Verify standalone invocations of sub-skills respect the "standalone" compact guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)