### PR TITLE
feat(kernel-eval): GCS FUSE mount for profiling persistence

### DIFF
--- a/.github/ci/kernel-eval-job.yaml
+++ b/.github/ci/kernel-eval-job.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: kernel-eval
         job-name: ${JOB_NAME}
+      annotations:
+        gke-gcsfuse/volumes: "true"
     spec:
       serviceAccountName: kernel-eval
       containers:
@@ -39,12 +41,16 @@ spec:
            cd /workspace && git checkout "$BRANCH")
           cd /workspace
           uv pip install --system -e kernel-evolve/
-          python kernel-evolve/docker/evaluate.py --eval-payload-file /etc/eval-payload/payload
+          python kernel-evolve/docker/evaluate.py \
+            --eval-payload-file /etc/eval-payload/payload \
+            --profile-dir /profiles/${JOB_NAME}
         env:
         - name: BRANCH
           value: "${BRANCH}"
         - name: REPO
           value: "${REPO}"
+        - name: JOB_NAME
+          value: "${JOB_NAME}"
         - name: JAX_PLATFORMS
           value: "tpu,cpu"
         - name: ENABLE_PJRT_COMPATIBILITY
@@ -64,13 +70,21 @@ spec:
         - name: eval-payload
           mountPath: /etc/eval-payload
           readOnly: true
+        - name: gcs-profiles
+          mountPath: /profiles
       volumes:
       - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: gke-gcsfuse-cache
         emptyDir:
           medium: Memory
       - name: eval-payload
         configMap:
           name: ${JOB_NAME}-payload
+      - name: gcs-profiles
+        persistentVolumeClaim:
+          claimName: glaucis-profiles-pvc
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x
         cloud.google.com/gke-tpu-topology: 2x2x1

--- a/kernel-evolve/docker/evaluate.py
+++ b/kernel-evolve/docker/evaluate.py
@@ -939,6 +939,8 @@ def main():
   parser.add_argument("--eval-payload", required=False)
   parser.add_argument("--eval-payload-file", required=False,
                       help="Path to file containing base64 payload")
+  parser.add_argument("--profile-dir", required=False,
+                      help="Directory to persist profiling artifacts (e.g. GCS FUSE mount)")
   args = parser.parse_args()
   if args.eval_payload_file:
     with open(args.eval_payload_file) as f:
@@ -1046,6 +1048,37 @@ def main():
   if gcs_result["ok"]:
     print(f"Uploaded artifacts: {gcs_result['uploaded']} to {gcs_result['gcs_prefix']}", file=sys.stderr)
 
+  # ── Persist profiling artifacts to --profile-dir (e.g. GCS FUSE mount) ──
+  profile_dir = args.profile_dir if hasattr(args, "profile_dir") else None
+  if profile_dir:
+    import shutil
+    pdir = Path(profile_dir)
+    pdir.mkdir(parents=True, exist_ok=True)
+    for name, local_path in artifacts.items():
+      if os.path.exists(local_path):
+        try:
+          shutil.copy2(local_path, pdir / name)
+          print(f"Persisted {name} -> {pdir / name}", file=sys.stderr)
+        except Exception as e:
+          print(f"Failed to persist {name}: {e}", file=sys.stderr)
+    # Also persist xplane.pb files directly for offline analysis
+    xplane_dir = Path("/tmp/xplane_trace/kernel")
+    if xplane_dir.exists():
+      xplane_out = pdir / "xplane"
+      xplane_out.mkdir(parents=True, exist_ok=True)
+      for root, _dirs, files in os.walk(xplane_dir):
+        for f in files:
+          if f.endswith(".xplane.pb"):
+            try:
+              shutil.copy2(os.path.join(root, f), xplane_out / f)
+              print(f"Persisted xplane: {f}", file=sys.stderr)
+            except Exception as e:
+              print(f"Failed to persist xplane {f}: {e}", file=sys.stderr)
+    # Persist eval_result.json for easy access
+    _profile_result_path = pdir / "eval_result.json"
+  else:
+    _profile_result_path = None
+
   # Strip internal fields from deep_profile before including in result
   clean_deep_profile = {k: v for k, v in deep_profile.items() if not k.startswith("_")}
 
@@ -1071,6 +1104,14 @@ def main():
   }
   print(f"EVAL_RESULT:{json.dumps(result)}")
 
+  # Write eval_result.json to profile dir if configured
+  if _profile_result_path:
+    try:
+      _profile_result_path.write_text(json.dumps(result, indent=2))
+      print(f"Persisted eval_result.json -> {_profile_result_path}", file=sys.stderr)
+    except Exception as e:
+      print(f"Failed to persist eval_result.json: {e}", file=sys.stderr)
+
 
 if __name__ == "__main__":
   # Parse payload to check for batch mode BEFORE setting up dump env.
@@ -1079,6 +1120,8 @@ if __name__ == "__main__":
   _parser.add_argument("--eval-payload", required=False)
   _parser.add_argument("--eval-payload-file", required=False,
                         help="Path to file containing base64 payload")
+  _parser.add_argument("--profile-dir", required=False,
+                        help="Directory to persist profiling artifacts (e.g. GCS FUSE mount)")
   _args = _parser.parse_args()
   if _args.eval_payload_file:
     with open(_args.eval_payload_file) as f:

--- a/kernel-evolve/src/kernel_evolve/config.py
+++ b/kernel-evolve/src/kernel_evolve/config.py
@@ -50,6 +50,35 @@ class BatchConfig(BaseModel):
   max_active_lineages: int = Field(default=4, ge=1)
 
 
+class HardwareConfig(BaseModel):
+  """Target TPU hardware specs for roofline analysis."""
+  chip: str = "v7x"
+  peak_flops_tflops: float = 2307.0       # BF16 peak TFLOPS
+  fp8_flops_tflops: float | None = None   # FP8 peak (None = 2x bf16)
+  peak_hbm_bw_gbps: float = 3690.0        # HBM bandwidth GB/s
+  hbm_capacity_gb: float = 192.0          # HBM capacity GB
+  vmem_capacity_mib: float = 64.0         # VMEM per chip MiB
+  num_mxu: int = 2                        # MXU units (for dual-issue target)
+
+
+class TilingConstraints(BaseModel):
+  """Hard constraints on tile dimensions."""
+  tm_must_divide: str | None = None       # e.g. "group_size" — tm must divide this
+  tk_must_divide: str | None = None       # e.g. "block_size"
+  min_tile: int = 64                      # minimum tile dimension
+  max_tile: int = 1024                    # maximum tile dimension
+  tk_multiple_of_block_size: bool = True  # tk must be a multiple of block_size
+
+
+class ConstraintsConfig(BaseModel):
+  """Optimization constraints that persist across rounds."""
+  vmem_budget_mib: float | None = None       # max VMEM usage (None = no limit)
+  compile_time_budget_s: float | None = None # max XLA compile time
+  tiling: TilingConstraints = Field(default_factory=TilingConstraints)
+  hard_rules: list[str] = Field(default_factory=list)
+  performance_targets: dict[str, float] = Field(default_factory=dict)
+
+
 class EvolveConfig(BaseModel):
   model_config = {"extra": "forbid"}
 
@@ -60,6 +89,8 @@ class EvolveConfig(BaseModel):
   tpu: TPUConfig
   session: SessionConfig = Field(default_factory=SessionConfig)
   batch: BatchConfig = Field(default_factory=BatchConfig)
+  hardware: HardwareConfig = Field(default_factory=HardwareConfig)
+  constraints: ConstraintsConfig = Field(default_factory=ConstraintsConfig)
 
 
 def load_config(path: str | Path) -> EvolveConfig:


### PR DESCRIPTION
## Summary
- Mount `glaucis-profiles` GCS bucket at `/profiles` via GCS FUSE CSI driver in kernel-eval jobs
- Add `--profile-dir` flag to `evaluate.py` to persist profiling artifacts (xplane.pb, trace_events.json, hlo_post_opt.txt, llo_final.txt, eval_result.json) directly to the GCS FUSE mount
- Add `HardwareConfig` and `ConstraintsConfig` Pydantic models to `EvolveConfig` for TPU hardware specs and optimization constraints that persist across rounds

## Infrastructure Setup (already done)
- Created PV `glaucis-profiles-pv` + PVC `glaucis-profiles-pvc` for the GCS FUSE mount
- Granted `kernel-eval` SA `storage.objectAdmin` on `gs://glaucis-profiles/`

## Test plan
- [ ] Verify PVC is bound: `kubectl get pvc glaucis-profiles-pvc`
- [ ] Submit a kernel eval job with the new template and confirm profiling files appear in `gs://glaucis-profiles/<job-name>/`
- [ ] Verify `load_config()` accepts new `hardware` and `constraints` YAML sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)